### PR TITLE
Improve support for managing associated posts via REST

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -56,3 +56,44 @@ function get_term_id( int $post_id ) : int {
 
 	return (int) $term->term_id;
 }
+
+/**
+ * Retrieve a list of associated posts stored when a post is
+ * in a non-published state.
+ *
+ * @param int $post_id The post ID.
+ * @return array A list of associated posts.
+ */
+function get_associated_posts( int $post_id ) : array {
+	$taxonomy_slug = get_taxonomy_slug( $post_id );
+
+	if ( '' === $taxonomy_slug ) {
+		return [];
+	}
+
+	$posts = get_post_meta( $post_id, $taxonomy_slug . '_associated_posts', true );
+
+	if ( ! $posts ) {
+		return [];
+	}
+
+	$posts = array_map( 'intval', $posts );
+
+	return (array) $posts;
+}
+
+/**
+ * Update a list of a post's associated posts.
+ *
+ * @param int        $post_id The original post.
+ * @param array[int] $posts   A list of associated post IDs.
+ */
+function update_associated_posts( int $post_id, array $posts ) : void {
+	$taxonomy_slug = get_taxonomy_slug( $post_id );
+
+	if ( '' === $taxonomy_slug ) {
+		return;
+	}
+
+	update_post_meta( $post_id, $taxonomy_slug . '_associated_posts', $posts );
+}

--- a/includes/taxonomy.php
+++ b/includes/taxonomy.php
@@ -7,6 +7,8 @@
 
 namespace ShadowTerms\Taxonomy;
 
+use ShadowTerms\API;
+
 add_action( 'init', __NAMESPACE__ . '\register', 9999 );
 
 /**
@@ -17,7 +19,19 @@ function register() {
 
 	foreach ( $post_types as $post_type ) {
 		register_taxonomy( $post_type );
+		register_rest_fields( $post_type );
 	}
+
+	// Register a REST route used to associate posts with a post's shadow term.
+	register_rest_route(
+		'shadow-terms/v1',
+		'associate',
+		array(
+			'methods'             => \WP_REST_Server::CREATABLE,
+			'callback'            => __NAMESPACE__ . '\handle_rest_associate',
+			'permission_callback' => __NAMESPACE__ . '\can_associate_posts',
+		)
+	);
 }
 
 /**
@@ -66,4 +80,123 @@ function register_taxonomy( string $post_type ) {
 		get_connected_post_types( $post_type ),
 		$args
 	);
+}
+
+/**
+ * Determine whether a user can associated shadow terms with posts.
+ *
+ * @return bool True if capable. False if not.
+ */
+function can_associate_posts() : bool {
+	return current_user_can( 'edit_posts' );
+}
+
+/**
+ * Handle the submission of a post association via REST request.
+ *
+ * @param \WP_REST_Request $request The vote submission request.
+ * @return \WP_REST_Response The response data.
+ */
+function handle_rest_associate( \WP_REST_Request $request ) : \WP_REST_Response {
+	$post_id            = (int) $request->get_param( 'postId' );
+	$associated_post_id = (int) $request->get_param( 'associatedPostId' );
+
+	if ( ! API\get_taxonomy_slug( $post_id ) ) {
+		return rest_ensure_response(
+			[
+				'success' => false,
+				'message' => 'This post type is not associated with a shadow taxonomy.',
+			]
+		);
+	}
+
+	$post = get_post( $post_id );
+
+	if ( 'publish' !== $post->post_status ) {
+		$associated_posts = API\get_associated_posts( $post_id );
+
+		if ( ! in_array( $associated_post_id, $associated_posts, true ) ) {
+			$associated_posts[] = $associated_post_id;
+			API\update_associated_posts( $post_id, $associated_posts );
+		}
+
+		return rest_ensure_response( [] );
+	}
+
+	wp_set_object_terms( $associated_post_id, API\get_term_id( $post_id ), API\get_taxonomy_slug( $post_id ) );
+
+	return rest_ensure_response( [] );
+}
+
+/**
+ * Register a field on the post type's REST response for the shadow term ID.
+ *
+ * @param string $post_type The post type.
+ */
+function register_rest_fields( string $post_type ) {
+
+	// Register a field on each post type to provide a list of associated posts
+	// when the original post is in a non-published state.
+	register_rest_field(
+		$post_type,
+		'shadowTermPosts',
+		[
+			'get_callback' => __NAMESPACE__ . '\populate_associated_posts',
+		]
+	);
+
+	// Register a field on each post type to provide the post's corresponding
+	// shadow term ID when it is in a published state.
+	register_rest_field(
+		$post_type,
+		'shadowTermId',
+		[
+			'get_callback' => __NAMESPACE__ . '\populate_shadow_term_id',
+		]
+	);
+
+	// Register a field on each post type to provide its shadow taxonomy slug.
+	register_rest_field(
+		$post_type,
+		'shadowTermSlug',
+		[
+			'get_callback' => __NAMESPACE__ . '\populate_shadow_term_slug',
+		]
+	);
+}
+
+/**
+ * Populate the post's associated posts as part of the REST response.
+ *
+ * @param array $post The post data as built for the response.
+ * @return array A list of associated posts.
+ */
+function populate_associated_posts( array $post ) : array {
+	$posts = get_post_meta( $post['id'], API\get_taxonomy_slug( $post['id'] ) . '_associated_posts', true );
+
+	if ( $posts ) {
+		return (array) $posts;
+	}
+
+	return [];
+}
+
+/**
+ * Populate the post's shadow term ID as part of the REST response.
+ *
+ * @param array $post The post data as built for the response.
+ * @return int The shadow term ID.
+ */
+function populate_shadow_term_id( array $post ) : int {
+	return API\get_term_id( $post['id'] );
+}
+
+/**
+ * Populate the post type's shadow taxonomy slug as part of the REST response.
+ *
+ * @param array $post The post data as built for the response.
+ * @return string The shadow taxonomy slug.
+ */
+function populate_shadow_term_slug( array $post ) : string {
+	return API\get_taxonomy_slug( $post['id'] );
 }

--- a/includes/taxonomy.php
+++ b/includes/taxonomy.php
@@ -151,39 +151,3 @@ function handle_rest_associate( \WP_REST_Request $request ) : \WP_REST_Response 
 
 	return rest_ensure_response( [ 'posts' => $associated_posts->posts ] );
 }
-
-/**
- * Populate the post's associated posts as part of the REST response.
- *
- * @param array $post The post data as built for the response.
- * @return array A list of associated posts.
- */
-function populate_associated_posts( array $post ) : array {
-	$posts = get_post_meta( $post['id'], API\get_taxonomy_slug( $post['id'] ) . '_associated_posts', true );
-
-	if ( $posts ) {
-		return (array) $posts;
-	}
-
-	return [];
-}
-
-/**
- * Populate the post's shadow term ID as part of the REST response.
- *
- * @param array $post The post data as built for the response.
- * @return int The shadow term ID.
- */
-function populate_shadow_term_id( array $post ) : int {
-	return API\get_term_id( $post['id'] );
-}
-
-/**
- * Populate the post type's shadow taxonomy slug as part of the REST response.
- *
- * @param array $post The post data as built for the response.
- * @return string The shadow taxonomy slug.
- */
-function populate_shadow_term_slug( array $post ) : string {
-	return API\get_taxonomy_slug( $post['id'] );
-}

--- a/includes/taxonomy.php
+++ b/includes/taxonomy.php
@@ -20,7 +20,6 @@ function register() {
 
 	foreach ( $post_types as $post_type ) {
 		register_taxonomy( $post_type );
-		register_rest_fields( $post_type );
 	}
 }
 
@@ -151,43 +150,6 @@ function handle_rest_associate( \WP_REST_Request $request ) : \WP_REST_Response 
 	);
 
 	return rest_ensure_response( [ 'posts' => $associated_posts->posts ] );
-}
-
-/**
- * Register a field on the post type's REST response for the shadow term ID.
- *
- * @param string $post_type The post type.
- */
-function register_rest_fields( string $post_type ) {
-
-	// Register a field on each post type to provide a list of associated posts
-	// when the original post is in a non-published state.
-	register_rest_field(
-		$post_type,
-		'shadowTermPosts',
-		[
-			'get_callback' => __NAMESPACE__ . '\populate_associated_posts',
-		]
-	);
-
-	// Register a field on each post type to provide the post's corresponding
-	// shadow term ID when it is in a published state.
-	register_rest_field(
-		$post_type,
-		'shadowTermId',
-		[
-			'get_callback' => __NAMESPACE__ . '\populate_shadow_term_id',
-		]
-	);
-
-	// Register a field on each post type to provide its shadow taxonomy slug.
-	register_rest_field(
-		$post_type,
-		'shadowTermSlug',
-		[
-			'get_callback' => __NAMESPACE__ . '\populate_shadow_term_slug',
-		]
-	);
 }
 
 /**

--- a/includes/taxonomy.php
+++ b/includes/taxonomy.php
@@ -10,6 +10,7 @@ namespace ShadowTerms\Taxonomy;
 use ShadowTerms\API;
 
 add_action( 'init', __NAMESPACE__ . '\register', 9999 );
+add_action( 'rest_api_init', __NAMESPACE__ . '\register_route' );
 
 /**
  * Register all shadow taxonomies.
@@ -21,7 +22,12 @@ function register() {
 		register_taxonomy( $post_type );
 		register_rest_fields( $post_type );
 	}
+}
 
+/**
+ * Register Shadow Term REST routes.
+ */
+function register_route() {
 	// Register a REST route used to associate posts with a post's shadow term.
 	register_rest_route(
 		'shadow-terms/v1',

--- a/includes/taxonomy.php
+++ b/includes/taxonomy.php
@@ -111,6 +111,7 @@ function handle_rest_associate( \WP_REST_Request $request ) : \WP_REST_Response 
 			[
 				'success' => false,
 				'message' => 'This post type is not associated with a shadow taxonomy.',
+				'posts'   => [],
 			]
 		);
 	}
@@ -125,7 +126,13 @@ function handle_rest_associate( \WP_REST_Request $request ) : \WP_REST_Response 
 			API\update_associated_posts( $post_id, $associated_posts );
 		}
 
-		return rest_ensure_response( [ 'posts' => $associated_posts ] );
+		return rest_ensure_response(
+			[
+				'success' => true,
+				'message' => '',
+				'posts'   => $associated_posts,
+			]
+		);
 	}
 
 	wp_set_object_terms( $associated_post_id, API\get_term_id( $post_id ), API\get_taxonomy_slug( $post_id ) );
@@ -149,5 +156,11 @@ function handle_rest_associate( \WP_REST_Request $request ) : \WP_REST_Response 
 		]
 	);
 
-	return rest_ensure_response( [ 'posts' => $associated_posts->posts ] );
+	return rest_ensure_response(
+		[
+			'success' => true,
+			'message' => '',
+			'posts'   => $associated_posts->posts,
+		]
+	);
 }


### PR DESCRIPTION
Introduces a REST endpoint at `shadow-terms/v1/associate` that accepts two paramters, `postId` and `associatedPostId`. This endpoint associates a post with another via a shadow term or, if the post is in a non-published state, as a post ID in its associated post meta.

I think the design of this may change a little bit over the next week, but is pretty close to something I'm happy with. :)