### PR TITLE
Fix post/term slug syncing when title or slug is updated

### DIFF
--- a/includes/sync.php
+++ b/includes/sync.php
@@ -67,8 +67,7 @@ function sync_shadow_taxonomies( int $post_id, \WP_Post $post_after, bool $updat
 		return;
 	}
 
-	$changed = $title_before !== $title_after;
-	$changed = $changed || ( $slug_before !== $slug_after );
+	$changed = $title_before !== $title_after || $slug_before !== $slug_after;
 
 	// If a post is to remain published, but the title or slug has changed, update the term.
 	if ( $term_before && 'publish' === $post_after->post_status && $changed ) {

--- a/includes/sync.php
+++ b/includes/sync.php
@@ -28,6 +28,8 @@ function sync_shadow_taxonomies( int $post_id, \WP_Post $post_after, bool $updat
 	$status_after  = $post_after->post_status;
 	$title_before  = null === $post_before ? '' : $post_before->post_title;
 	$title_after   = $post_after->post_title;
+	$slug_before   = null === $post_before ? '' : $post_before->post_name;
+	$slug_after    = $post_after->post_name;
 
 	// One version of the post must be published for us to make a change.
 	if ( ! in_array( 'publish', array( $status_before, $status_after ), true ) ) {
@@ -65,14 +67,17 @@ function sync_shadow_taxonomies( int $post_id, \WP_Post $post_after, bool $updat
 		return;
 	}
 
-	// If a post is to remain published, but the title has changed, update the term.
-	if ( $term_before && 'publish' === $post_after->post_status && $title_before !== $title_after ) {
+	$changed = $title_before !== $title_after;
+	$changed = $changed || ( $slug_before !== $slug_after );
+
+	// If a post is to remain published, but the title or slug has changed, update the term.
+	if ( $term_before && 'publish' === $post_after->post_status && $changed ) {
 		wp_update_term(
 			$term_before->term_id,
 			$taxonomy,
 			array(
 				'name' => $title_after,
-				'slug' => sanitize_title( $title_after ),
+				'slug' => $slug_after,
 			)
 		);
 

--- a/tests/test-term-sync.php
+++ b/tests/test-term-sync.php
@@ -404,10 +404,12 @@ class TestTermSync extends WP_UnitTestCase {
 		$post->post_title = 'Chickpea';
 		wp_update_post( $post );
 
+		// A term should exist for the original slug.
 		$term      = get_term_by( 'slug', 'garbanzo-bean', 'example_connect', OBJECT );
 		$term_name = ! $term ? '' : $term->name;
 
-		$this->assertEquals( 'Chickpea', $term_name, 'A connected term slug should update when a post title is updated.' );
+		// And that term's name should match the updated post title.
+		$this->assertEquals( 'Chickpea', $term_name, 'A connected term name should update when a post title is updated, but the term slug should remain the same.' );
 	}
 
 	/**
@@ -427,9 +429,11 @@ class TestTermSync extends WP_UnitTestCase {
 		$post->post_name = 'chickpea';
 		wp_update_post( $post );
 
+		// A term should exist for the new slug.
 		$term      = get_term_by( 'slug', 'chickpea', 'example_connect', OBJECT );
 		$term_name = ! $term ? '' : $term->name;
 
+		// And that term's name should still match the unmodified post title.
 		$this->assertEquals( 'Garbanzo Bean', $term_name, 'A connected term slug should update when a post slug is updated.' );
 	}
 
@@ -451,9 +455,11 @@ class TestTermSync extends WP_UnitTestCase {
 		$post->post_name  = 'chickpea';
 		wp_update_post( $post );
 
+		// A term should exist for the new slug.
 		$term      = get_term_by( 'slug', 'chickpea', 'example_connect', OBJECT );
 		$term_name = ! $term ? '' : $term->name;
 
-		$this->assertEquals( 'Chickpea', $term_name, 'A connected term slug should update when its post title and slug is updated.' );
+		// And that term's name should match the updated post's title.
+		$this->assertEquals( 'Chickpea', $term_name, 'A connected term slug and term name should update when its post title and slug is updated.' );
 	}
 }

--- a/tests/test-term-sync.php
+++ b/tests/test-term-sync.php
@@ -386,4 +386,74 @@ class TestTermSync extends WP_UnitTestCase {
 
 		$this->assertEquals( array( $term->slug ), $associated_terms, 'Existing shadow term relationships should be restored when its connected post is moved from trash to publish.' );
 	}
+
+	/**
+	 * An existing published post that has its title changed should change the
+	 * title of its shadow term.
+	 */
+	public function test_post_publish_to_publish_modified_title_updates_term() {
+		$post = $this->factory->post->create(
+			array(
+				'post_type'   => 'example',
+				'post_title'  => 'Garbanzo Bean',
+				'post_status' => 'publish',
+			)
+		);
+		$post = get_post( $post );
+
+		$post->post_title = 'Chickpea';
+		wp_update_post( $post );
+
+		$term      = get_term_by( 'slug', 'garbanzo-bean', 'example_connect', OBJECT );
+		$term_name = ! $term ? '' : $term->name;
+
+		$this->assertEquals( 'Chickpea', $term_name, 'A connected term slug should update when a post title is updated.' );
+	}
+
+	/**
+	 * An existing published post that has its slug changed should change the
+	 * slug of its shadow term.
+	 */
+	public function test_post_publish_to_publish_modified_slug_updates_term() {
+		$post = $this->factory->post->create(
+			array(
+				'post_type'   => 'example',
+				'post_title'  => 'Garbanzo Bean',
+				'post_status' => 'publish',
+			)
+		);
+		$post = get_post( $post );
+
+		$post->post_name = 'chickpea';
+		wp_update_post( $post );
+
+		$term      = get_term_by( 'slug', 'chickpea', 'example_connect', OBJECT );
+		$term_name = ! $term ? '' : $term->name;
+
+		$this->assertEquals( 'Garbanzo Bean', $term_name, 'A connected term slug should update when a post slug is updated.' );
+	}
+
+	/**
+	 * An existing published post that has its title changed should change the
+	 * title of its shadow term.
+	 */
+	public function test_post_publish_to_publish_modified_title_and_slug_updates_term() {
+		$post = $this->factory->post->create(
+			array(
+				'post_type'   => 'example',
+				'post_title'  => 'Garbanzo Bean',
+				'post_status' => 'publish',
+			)
+		);
+		$post = get_post( $post );
+
+		$post->post_title = 'Chickpea';
+		$post->post_name  = 'chickpea';
+		wp_update_post( $post );
+
+		$term      = get_term_by( 'slug', 'chickpea', 'example_connect', OBJECT );
+		$term_name = ! $term ? '' : $term->name;
+
+		$this->assertEquals( 'Chickpea', $term_name, 'A connected term slug should update when its post title and slug is updated.' );
+	}
 }


### PR DESCRIPTION
Previously, when a title was updated, we would automatically change the shadow term slug to match that title.

Also previously, when a slug was updated, the change would never make its way to the shadow term.

With this change, title and slug are both modified as they are changed with the post.