### PR TITLE
Require custom capabilities to manage/edit/delete shadow terms

### DIFF
--- a/includes/taxonomy.php
+++ b/includes/taxonomy.php
@@ -67,6 +67,11 @@ function register_taxonomy( string $post_type ): void {
 		'publicly_queryable' => false,
 		'rewrite'            => false,
 		'hierarchical'       => true,
+		'capabilities'       => array(
+			'manage_terms' => 'override_shadow_terms',
+			'edit_terms'   => 'override_shadow_terms',
+			'delete_terms' => 'override_shadow_terms',
+		),
 		'show_ui'            => true,
 		'show_in_menu'       => false,
 		'show_in_nav_menus'  => false,


### PR DESCRIPTION
This prevents UI appearing in the admin without impacting the existing logic in this plugin for creating, editing, and deleting terms.

See #45, Fixes #20.