### PR TITLE
Ensure `shadow-terms` key exists before checking it

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -110,7 +110,7 @@ function get_post_id( int $term_id ): int {
 function get_connected_post_types( string $post_type ): array {
 	$supports = get_all_post_type_supports( $post_type );
 
-	if ( is_array( $supports['shadow-terms'] ) && is_array( $supports['shadow-terms'][0] ) ) {
+	if ( isset( $supports['shadow-terms'] ) && is_array( $supports['shadow-terms'] ) && is_array( $supports['shadow-terms'][0] ) ) {
 		return $supports['shadow-terms'][0];
 	}
 


### PR DESCRIPTION
If an attempt is made to get the connected post types of a post type that does not support shadow terms, then this would result in an undefined array key notice.