### PR TITLE
Update 10up/action-wordpress-plugin-asset-update action

### DIFF
--- a/.github/workflows/deploy-to-readme.yml
+++ b/.github/workflows/deploy-to-readme.yml
@@ -10,7 +10,7 @@ jobs:
             - uses: actions/checkout@master
             - run: mkdir -p .wordpress-org
             - name: WordPress.org plugin asset/readme update
-              uses: 10up/action-wordpress-plugin-asset-update@2.1.3
+              uses: 10up/action-wordpress-plugin-asset-update@stable
               env:
                   SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
                   SVN_USERNAME: ${{ secrets.SVN_USERNAME }}


### PR DESCRIPTION
All other plugins have `stable`
https://github.com/search?q=org%3Ahappyprime%2010up%2Faction-wordpress-plugin-asset-update&type=code
`svn` command is necessary
https://github.com/10up/action-wordpress-plugin-asset-update/releases/tag/2.2.0
