### PR TITLE
Update coding standards configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+	"name": "Shadow Terms",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+	},
+	"postCreateCommand": "npm -g install @wordpress/env",
+	"forwardPorts": [8888],
+	"portsAttributes": {
+		"8888": {
+			"label": "WordPress",
+			"onAutoForward": "notify"
+		}
+	}
+}

--- a/.distignore
+++ b/.distignore
@@ -3,6 +3,7 @@ bin/
 tests/
 vendor/
 .distignore
+.editorconfig
 .git
 .gitignore
 .phpcs.xml.dist

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 vendor
 .phpunit.result.cache
-.claude
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 .phpunit.result.cache
+.claude

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,12 @@
+{
+	"core": "WordPress/WordPress#6.9",
+	"phpVersion": "8.2",
+	"plugins": [
+		"."
+	],
+	"config": {
+		"WP_DEBUG": true,
+		"WP_DEBUG_LOG": true,
+		"SCRIPT_DEBUG": true
+	}
+}

--- a/blueprint.json
+++ b/blueprint.json
@@ -1,0 +1,19 @@
+{
+	"landingPage": "/wp-admin/plugins.php",
+	"preferredVersions": {
+		"php": "8.2",
+		"wp": "latest"
+	},
+	"steps": [
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "shadow-terms"
+			}
+		},
+		{
+			"step": "login"
+		}
+	]
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,9 +3,6 @@
 	bootstrap="tests/bootstrap.php"
 	backupGlobals="false"
 	colors="true"
-	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true"
 	>
 	<testsuites>
 		<testsuite name="Plugin tests">


### PR DESCRIPTION
## Summary
- Remove deprecated PHPUnit 10 attributes (`convertErrorsToExceptions`, `convertNoticesToExceptions`, `convertWarningsToExceptions`) from `phpunit.xml.dist`
- Add `.editorconfig` for consistent editor formatting
- Add `.claude` to `.gitignore`

## Test plan
- [ ] Verify `composer phpunit` still runs
- [ ] Verify `composer phpcs` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)